### PR TITLE
Fix fuzzy champion matching

### DIFF
--- a/lib/api/StaticData.js
+++ b/lib/api/StaticData.js
@@ -134,10 +134,10 @@ function getChampionByName (region, name, options) {
   .then(champions => {
     var answer, championsByName
     answer = champions.data[name]
-    if (answer === null) {
+    if (typeof answer === "undefined") {
       championsByName = R.indexBy(c => {
         return R.toLower(R.replace(/\W/g, '', c.name))
-      })
+      }, R.values(champions.data))
       answer = championsByName[R.toLower(R.replace(/\W/g, '', name))]
     }
     return answer


### PR DESCRIPTION
Reading a non-existent entry returns `undefined`, not `null`. The indexBy call also lacked an actual list to work on. I confirmed that this works for both incorrect capitalization and lack of special characters (khazix matches Kha'Zix). Don't forget to update the version number if you merge this 😄 